### PR TITLE
added getFilename function to get the name only an write it to the array

### DIFF
--- a/tasks/folder_list.js
+++ b/tasks/folder_list.js
@@ -56,6 +56,10 @@ module.exports = function (grunt) {
                 return ext[ext.length - 1];
             }
 
+            function getFilename(filename){
+                var ext = path.basename(filename || '');
+                return ext;
+            }
 
             // Output variables
             var structure = [],
@@ -88,7 +92,8 @@ module.exports = function (grunt) {
                         type: 'file',
                         size: getFilesizeInBytes(cwd + filename),
                         depth: filename.split('/').length - 1,
-                        filetype: getExtension(cwd + filename)
+                        filetype: getExtension(cwd + filename),
+                        name: getFilename(cwd + filename)
                     }
                     if (options.files) {
                         structure.push(tempInfo);


### PR DESCRIPTION
I just needed the pure file name without it's extension, wherefore I used node's path.basename.
Could you merge the getFilename function into your very helpful task?
